### PR TITLE
Fix: correct type-only imports for verbatimModuleSyntax

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -5,6 +5,9 @@ import { defineConfig } from "eslint/config";
 
 export default defineConfig([
   {
+    ignores: ["dist/**"],
+  },
+  {
     files: ["**/*.{js,mjs,cjs,ts,mts,cts,jsx,tsx}"],
     languageOptions: {
       globals: globals.browser,

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,4 +1,4 @@
-import { Component, ErrorInfo, ReactNode } from "react";
+import { Component, type ErrorInfo, type ReactNode } from "react";
 
 interface Props {
   children: ReactNode;


### PR DESCRIPTION
This commit fixes the TypeScript errors related to `verbatimModuleSyntax: true` in tsconfig.json.

- Updated `src/components/ErrorBoundary.tsx` to use type-only imports for `ErrorInfo` and `ReactNode`.
- Audited the project for other similar errors and found none.
- Configured ESLint to ignore the `dist` directory to prevent linting build artifacts.